### PR TITLE
Fix wrong usage of "detail" object of mozbrowserlocationchange event

### DIFF
--- a/main.js
+++ b/main.js
@@ -109,7 +109,7 @@ browser.addEventListener('mozbrowserloadend',function(e) {
 });
 
 browser.addEventListener('mozbrowserlocationchange', function (e) {
-  urlBar.value = e.detail;
+  urlBar.value = e.detail.url;
 });
 
 browser.addEventListener('mozbrowsererror', function (e) {


### PR DESCRIPTION
We followed the following documentation's usage.
https://developer.mozilla.org/ja/docs/Web/Events/mozbrowserlocationchange